### PR TITLE
Update Sphinx image to version 1744610599

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@ services:
     # build:
     #   context: docker
     #   dockerfile: Dockerfile
-    image: ghcr.io/densuke/sphinx-texlive:1744093846
+    image: ghcr.io/densuke/sphinx-texlive:1744610599
 
     #user: worker
     volumes:


### PR DESCRIPTION
This PR updates the Sphinx image reference in compose.yml to the specific version: ghcr.io/densuke/sphinx-texlive:1744610599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the container image used by the application to the latest version, ensuring continued system reliability and performance without any visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->