### PR TITLE
Update Sphinx image to version 1749629055

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@ services:
     # build:
     #   context: docker
     #   dockerfile: Dockerfile
-    image: ghcr.io/densuke/sphinx-texlive:1744610599
+    image: ghcr.io/densuke/sphinx-texlive:1749629055
 
     #user: worker
     volumes:


### PR DESCRIPTION
This PR updates the Sphinx image reference in compose.yml to the specific version: ghcr.io/densuke/sphinx-texlive:1749629055