### PR TITLE
ベースイメージ更新

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@ services:
     # build:
     #   context: docker
     #   dockerfile: Dockerfile
-    image: ghcr.io/densuke/sphinx-texlive:20250808001355
+    image: ghcr.io/densuke/sphinx-texlive:20250902210808
 
     #user: worker
     volumes:


### PR DESCRIPTION
ベースイメージを更新しました。
glibライブラリがplaywright絡みで必要になりそうな出力が確認されたため、事前に入れているイメージに更新したという状況です。